### PR TITLE
#31 autofocus syntax

### DIFF
--- a/packages/core/src/components/editable.tsx
+++ b/packages/core/src/components/editable.tsx
@@ -1,17 +1,17 @@
-import { Editor, Node, type NodeEntry, Range } from 'slate'
+import debounce from 'lodash/debounce'
+import { Editor, Node, Range, type NodeEntry } from 'slate'
 import {
   CAN_USE_DOM,
   EDITOR_TO_ELEMENT,
   EDITOR_TO_WINDOW,
   ELEMENT_TO_NODE,
-  getDefaultView,
   HAS_BEFORE_INPUT_SUPPORT,
   NODE_TO_ELEMENT,
   PLACEHOLDER_SYMBOL,
+  getDefaultView,
   type DOMElement,
   type DOMRange,
 } from 'slate-dom'
-import { createOnDOMSelectionChange } from '../utils/createOnDOMSelectionChange'
 import {
   createEffect,
   createMemo,
@@ -20,37 +20,37 @@ import {
   splitProps,
   type JSX,
 } from 'solid-js'
-import debounce from 'lodash/debounce'
-import { useSlate } from '../hooks/useSlate'
-import { useRef } from '../hooks/useRef'
 import type { AndroidInputManager } from '../hooks/android-input-manager/android-input-manager'
+import { ComposingContext } from '../hooks/useComposing'
+import { DecorateContext } from '../hooks/useDecorate'
+import { ReadOnlyContext } from '../hooks/useReadOnly'
+import { useRef } from '../hooks/useRef'
+import { useSlate } from '../hooks/useSlate'
+import { useSyncEditableWeakMaps } from '../hooks/useSyncEditableWeakMaps'
+import { useTrackUserInput } from '../hooks/useTrackUserInput'
+import type { SolidEditor } from '../plugin/solid-editor'
+import { createOnBlur } from '../utils/createOnBlur'
+import { createOnClick } from '../utils/createOnClick'
+import { createOnCompositionEnd } from '../utils/createOnCompositionEnd'
+import { createOnCompositionStart } from '../utils/createOnCompositionStart'
+import { createOnCompositionUpdate } from '../utils/createOnCompositionUpdate'
+import { createOnDOMBeforeInput } from '../utils/createOnDOMBeforeInput'
+import { createOnDOMSelectionChange } from '../utils/createOnDOMSelectionChange'
+import { createOnFocus } from '../utils/createOnFocus'
+import { createOnInput } from '../utils/createOnInput'
+import { createOnKeyDown } from '../utils/createOnKeyDown'
+import { defaultDecorate } from '../utils/defaultDecorate'
+import { defaultScrollSelectionIntoView } from '../utils/defaultScrollSelectionIntoView'
+import { Logger } from '../utils/logger'
+import type { DeferredOperation } from '../utils/types'
+import { Children } from './children'
+import { DefaultPlaceholder } from './defaultPlaceholder'
 import type {
   RenderElementProps,
   RenderLeafProps,
   RenderPlaceholderProps,
 } from './propTypes'
-import type { SolidEditor } from '../plugin/solid-editor'
-import { defaultDecorate } from '../utils/defaultDecorate'
-import { createOnDOMBeforeInput } from '../utils/createOnDOMBeforeInput'
-import { useTrackUserInput } from '../hooks/useTrackUserInput'
-import type { DeferredOperation } from '../utils/types'
-import { Children } from './children'
-import { defaultScrollSelectionIntoView } from '../utils/defaultScrollSelectionIntoView'
-import { useSyncEditableWeakMaps } from '../hooks/useSyncEditableWeakMaps'
-import { Logger } from '../utils/logger'
-import { createOnKeyDown } from '../utils/createOnKeyDown'
-import { ReadOnlyContext } from '../hooks/useReadOnly'
-import { DecorateContext } from '../hooks/useDecorate'
 import { RerenderOnSignal } from './rerenderOnSignal'
-import { ComposingContext } from '../hooks/useComposing'
-import { DefaultPlaceholder } from './defaultPlaceholder'
-import { createOnClick } from '../utils/createOnClick'
-import { createOnInput } from '../utils/createOnInput'
-import { createOnBlur } from '../utils/createOnBlur'
-import { createOnFocus } from '../utils/createOnFocus'
-import { createOnCompositionStart } from '../utils/createOnCompositionStart'
-import { createOnCompositionEnd } from '../utils/createOnCompositionEnd'
-import { createOnCompositionUpdate } from '../utils/createOnCompositionUpdate'
 
 const logger = new Logger('Editable')
 

--- a/packages/core/src/components/editable.tsx
+++ b/packages/core/src/components/editable.tsx
@@ -71,7 +71,6 @@ export type EditableProps = {
 
 export function Editable(origProps: EditableProps) {
   const [namedProps, attributes] = splitProps(origProps, [
-    'autofocus',
     'decorate',
     'onDOMBeforeInput',
     'placeholder',

--- a/packages/core/src/components/editable.tsx
+++ b/packages/core/src/components/editable.tsx
@@ -217,6 +217,10 @@ export function Editable(origProps: EditableProps) {
       scheduleOnDOMSelectionChange,
     )
 
+    if (ref.current && attributes.autofocus) {
+      ref.current.focus()
+    }
+
     // TODO: Implement drag / drop handling
   })
 

--- a/src/examples/checkLists.tsx
+++ b/src/examples/checkLists.tsx
@@ -8,17 +8,17 @@ import {
   type RenderElementProps,
 } from '@slate-solid/core'
 import {
-  Editor,
-  Transforms,
-  Range,
-  Point,
-  createEditor,
   Descendant,
+  Editor,
+  Point,
+  Range,
   Element as SlateElement,
+  Transforms,
+  createEditor,
 } from 'slate'
 import { withHistory } from 'slate-history'
-import styles from './checkLists.module.css'
 import { createMemo } from 'solid-js'
+import styles from './checkLists.module.css'
 import { classNames } from './utils/cssUtils'
 
 const initialValue: Descendant[] = [
@@ -78,7 +78,7 @@ const CheckListsExample = () => {
         renderElement={renderElement}
         placeholder="Get to work…"
         spellcheck
-        autofocus
+        autoFocus
       />
     </Slate>
   )

--- a/src/examples/checkLists.tsx
+++ b/src/examples/checkLists.tsx
@@ -78,7 +78,7 @@ const CheckListsExample = () => {
         renderElement={renderElement}
         placeholder="Get to work…"
         spellcheck
-        autoFocus
+        autofocus
       />
     </Slate>
   )

--- a/src/examples/hugeDocument.tsx
+++ b/src/examples/hugeDocument.tsx
@@ -1,12 +1,12 @@
-import { createMemo, Match, Switch } from 'solid-js'
 import { faker } from '@faker-js/faker'
-import { createEditor, Descendant } from 'slate'
 import {
-  Slate,
   Editable,
+  Slate,
   withSolid,
   type RenderElementProps,
 } from '@slate-solid/core'
+import { createEditor, Descendant } from 'slate'
+import { createMemo, Match, Switch } from 'solid-js'
 
 const HEADINGS = 100
 const PARAGRAPHS = 7
@@ -31,7 +31,7 @@ const HugeDocumentExample = () => {
   const editor = createMemo(() => withSolid(createEditor()))
   return (
     <Slate editor={editor()} initialValue={initialValue}>
-      <Editable renderElement={renderElement} spellcheck autofocus />
+      <Editable renderElement={renderElement} spellcheck autoFocus />
     </Slate>
   )
 }

--- a/src/examples/hugeDocument.tsx
+++ b/src/examples/hugeDocument.tsx
@@ -5,8 +5,8 @@ import {
   withSolid,
   type RenderElementProps,
 } from '@slate-solid/core'
-import { createEditor, Descendant } from 'slate'
-import { createMemo, Match, Switch } from 'solid-js'
+import { Descendant, createEditor } from 'slate'
+import { Match, Switch, createMemo } from 'solid-js'
 
 const HEADINGS = 100
 const PARAGRAPHS = 7
@@ -31,7 +31,7 @@ const HugeDocumentExample = () => {
   const editor = createMemo(() => withSolid(createEditor()))
   return (
     <Slate editor={editor()} initialValue={initialValue}>
-      <Editable renderElement={renderElement} spellcheck autoFocus />
+      <Editable renderElement={renderElement} spellcheck autofocus />
     </Slate>
   )
 }

--- a/src/examples/richText.tsx
+++ b/src/examples/richText.tsx
@@ -69,7 +69,7 @@ export const RichTextExample = () => {
         renderLeaf={renderLeaf}
         placeholder="Enter some rich text…"
         spellcheck
-        autoFocus
+        autofocus
         // TODO: I don't think `onKeyDown` is implemented yet
         onKeyDown={(event) => {
           for (const hotkey in HOTKEYS) {

--- a/src/examples/richText.tsx
+++ b/src/examples/richText.tsx
@@ -1,22 +1,22 @@
-import { children, createMemo, Match, Switch, type JSX } from 'solid-js'
-import isHotkey from 'is-hotkey'
 import {
   Editable,
-  withSolid,
-  useSlate,
   Slate,
-  type RenderLeafProps,
+  useSlate,
+  withSolid,
   type RenderElementProps,
+  type RenderLeafProps,
   type SolidEditor,
 } from '@slate-solid/core'
+import isHotkey from 'is-hotkey'
 import {
+  Descendant,
   Editor,
+  Element as SlateElement,
   Transforms,
   createEditor,
-  Descendant,
-  Element as SlateElement,
 } from 'slate'
 import { withHistory } from 'slate-history'
+import { Match, Switch, children, createMemo, type JSX } from 'solid-js'
 
 import { Button, Icon, Toolbar, type IconType } from './components'
 import type {
@@ -69,7 +69,7 @@ export const RichTextExample = () => {
         renderLeaf={renderLeaf}
         placeholder="Enter some rich text…"
         spellcheck
-        autofocus
+        autoFocus
         // TODO: I don't think `onKeyDown` is implemented yet
         onKeyDown={(event) => {
           for (const hotkey in HOTKEYS) {


### PR DESCRIPTION
Fixes two issues 
https://github.com/slate-solid/slate-solid/issues/31

Includes an invisible fix for the richtext toolbar buttons not passing properties correctly. 