### PR TITLE
fix: Fixed issues with node WeakMaps not always getting updated

### DIFF
--- a/packages/core/src/components/children.tsx
+++ b/packages/core/src/components/children.tsx
@@ -1,4 +1,10 @@
-import { createMemo, For, type Accessor, type JSX } from 'solid-js'
+import {
+  createEffect,
+  createMemo,
+  For,
+  type Accessor,
+  type JSX,
+} from 'solid-js'
 import { type Ancestor, Range, Editor, Element } from 'slate'
 import { SolidEditor } from '../plugin/solid-editor'
 import type {
@@ -43,18 +49,7 @@ export function Children(props: ChildrenProps) {
   return (
     <For each={props.node.children}>
       {(n, i) => {
-        // This needs to run before Slate apis are called in this loop. This
-        // seems to be the easiest way to do this since effects won't run until
-        // after accessor calls throughout the loop
-        const updateWeakMaps = () => {
-          NODE_TO_INDEX.set(n, i())
-          NODE_TO_PARENT.set(n, props.node)
-        }
-
-        const childPath = () => {
-          updateWeakMaps()
-          return nodePath().concat(i())
-        }
+        const childPath = () => nodePath().concat(i())
 
         // const key = SolidEditor.findKey(editor(), n)
         const range = () => Editor.range(editor(), childPath())

--- a/packages/core/src/components/slate.tsx
+++ b/packages/core/src/components/slate.tsx
@@ -17,6 +17,7 @@ import {
 import { EditorContext } from '../hooks/useSlateStatic'
 import { SolidEditor } from '../plugin/solid-editor'
 import { Logger } from '../utils/logger'
+import { setNodeWeakMaps } from '../utils/setNodeWeakMaps'
 
 const logger = new Logger('Slate')
 
@@ -60,6 +61,8 @@ export const Slate = (origProps: {
     props.editor.children = props.initialValue
     Object.assign(props.editor, restProps)
 
+    setNodeWeakMaps(props.editor)
+
     return props.editor
   })
 
@@ -83,6 +86,8 @@ export const Slate = (origProps: {
     logger.debug('Selection:', JSON.stringify(editor().selection))
     logger.debug('Children:', JSON.stringify(editor().children, undefined, 2))
     logger.groupEnd()
+
+    setNodeWeakMaps(editor(), options?.operation)
 
     if (props.onChange) {
       props.onChange(editor().children)

--- a/packages/core/src/utils/setNodeWeakMaps.ts
+++ b/packages/core/src/utils/setNodeWeakMaps.ts
@@ -1,0 +1,90 @@
+import type { SolidEditor } from '@slate-solid/core'
+import {
+  Ancestor,
+  Text,
+  type Operation,
+  type SetNodeOperation,
+  type SetSelectionOperation,
+} from 'slate'
+import { NODE_TO_INDEX, NODE_TO_PARENT } from 'slate-dom'
+
+/**
+ * Set WeakMap entries related to nodes in the Slate data model. These provide
+ * easy access to nodes + related objects without having to traverse the node
+ * tree every time. This should be called on the initial state tree, and then
+ * again any time the node tree changes.
+ */
+export function setNodeWeakMaps(editor: SolidEditor, operation?: Operation) {
+  // Node tree shouldn't change on these operations
+  if (operation?.type === 'set_selection' || operation?.type === 'set_node') {
+    return
+  }
+
+  console.log(editor, operation)
+  const queue: Ancestor[] = [editor]
+
+  let childFilterIndex = getTopLevelFilterIndex(operation)
+
+  let c = 0
+  while (queue.length > 0) {
+    const parent = queue.shift()!
+    const children = parent.children
+
+    for (let i = 0; i < children.length; ++i) {
+      if (childFilterIndex && i !== childFilterIndex) {
+        continue
+      }
+
+      const child = children[i]
+
+      if (!Text.isText(child)) {
+        queue.push(child)
+      }
+
+      ++c
+      NODE_TO_INDEX.set(child, i)
+      NODE_TO_PARENT.set(child, parent)
+    }
+
+    // Only applies to top level, so clear any existing filter
+    childFilterIndex = null
+  }
+
+  console.log(`Processed ${c} nodes.`)
+}
+
+/**
+ * Get a filter index for direct child of Editor based on an operations. The
+ * idea here is that some operations should only require updating refs on a sub
+ * tree of the state tree.
+ * @param operation Optional operation to determine the filter index.
+ * @returns an index of the direct Editor child to process if an optimization
+ * can be identified. Otherwise returns null which means process everything.
+ */
+function getTopLevelFilterIndex(
+  operation?: Exclude<Operation, SetNodeOperation | SetSelectionOperation>,
+): number | null {
+  if (operation == null) {
+    return null
+  }
+
+  switch (operation.type) {
+    // TODO: There's probably more optimization that can be done for these
+    // operations, but there's likely edge cases to be thought through. Leaving
+    // unfiltered for now until we experience any actual performance issues that
+    // need further optimization.
+    case 'insert_node':
+    case 'merge_node':
+    case 'move_node':
+    case 'remove_node':
+    case 'split_node':
+      return null
+
+    // Text change operations should only impact the top-level child node downward,
+    // So should be able to just target that sub tree.
+    case 'insert_text':
+    case 'remove_text': {
+      return operation.path[0]
+    }
+  }
+}

--- a/packages/core/src/utils/setNodeWeakMaps.ts
+++ b/packages/core/src/utils/setNodeWeakMaps.ts
@@ -25,7 +25,7 @@ export function setNodeWeakMaps(editor: SolidEditor, operation?: Operation) {
   // of the editor should not be impacted and can be skipped over.
   let childFilterIndex = getTopLevelFilterIndex(operation)
 
-  // Traverse the node tree (or sub-tree if childFilterIndex is not unull).
+  // Traverse the node tree (or sub-tree if childFilterIndex is not null).
   // Using a queue to avoid recursive function calls.
   const queue: Ancestor[] = [editor]
   while (queue.length > 0) {

--- a/packages/core/src/utils/setNodeWeakMaps.ts
+++ b/packages/core/src/utils/setNodeWeakMaps.ts
@@ -20,11 +20,14 @@ export function setNodeWeakMaps(editor: SolidEditor, operation?: Operation) {
     return
   }
 
-  console.log(editor, operation)
-  const queue: Ancestor[] = [editor]
-
+  // Optimization to only process sub trees for certain operations. e.g. a text
+  // only change should only impact its ancestor tree. Other direct child nodes
+  // of the editor should not be impacted and can be skipped over.
   let childFilterIndex = getTopLevelFilterIndex(operation)
 
+  // Traverse the node tree (or sub-tree if childFilterIndex is not unull).
+  // Using a queue to avoid recursive function calls.
+  const queue: Ancestor[] = [editor]
   while (queue.length > 0) {
     const parent = queue.shift()!
     const children = parent.children

--- a/packages/core/src/utils/setNodeWeakMaps.ts
+++ b/packages/core/src/utils/setNodeWeakMaps.ts
@@ -25,7 +25,6 @@ export function setNodeWeakMaps(editor: SolidEditor, operation?: Operation) {
 
   let childFilterIndex = getTopLevelFilterIndex(operation)
 
-  let c = 0
   while (queue.length > 0) {
     const parent = queue.shift()!
     const children = parent.children
@@ -41,7 +40,6 @@ export function setNodeWeakMaps(editor: SolidEditor, operation?: Operation) {
         queue.push(child)
       }
 
-      ++c
       NODE_TO_INDEX.set(child, i)
       NODE_TO_PARENT.set(child, parent)
     }
@@ -49,8 +47,6 @@ export function setNodeWeakMaps(editor: SolidEditor, operation?: Operation) {
     // Only applies to top level, so clear any existing filter
     childFilterIndex = null
   }
-
-  console.log(`Processed ${c} nodes.`)
 }
 
 /**


### PR DESCRIPTION
Updating `NODE_TO_INDEX` and `NODE_TO_PARENT` needs to happen for the entire sub tree involved in a state tree mutation. The way I was updating these before was not updating all of the nodes before other code attempted to access it which was throwing errors. This seems to have been the cause of [Editable Voids Example Crashes #45](https://github.com/slate-solid/slate-solid/issues/45).

This PR changes the methodology to update weak refs immediately after a context change is applied which ensures the refs are in sync with the latest state tree before components attempt to access the refs.