### PR TITLE
fix: cannot find module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,9 +18,9 @@
   "typesVersions": {},
   "browser": {},
   "exports": {
-    "solid": {
-      "development": "./dist/index.jsx",
-      "import": "./dist/index.jsx"
+    ".": {
+      "solid": "./dist/index.jsx",
+      "default": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
I installed the package and it works properly, except TypeScript constantly complains that the module isn't found. I updated the exports so that it can find the module.